### PR TITLE
fix compatibility issue with alx-folder-note v0.15.0+

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ export interface FolderIconObject {
 
 export default class IconFolderPlugin extends Plugin {
   private data: Record<string, string | IconFolderSettings | FolderIconObject>;
-  private registeredFileExplorers = new WeakMap();
+  private registeredFileExplorers = new WeakSet<ExplorerView>();
 
   async onload() {
     console.log('loading obsidian-icon-folder');

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ import * as faFill from '../fontawesome/index-fill';
 import * as faBrands from '../fontawesome/index-brands';
 
 import IconFolderPlugin, { FolderIconObject } from './main';
-import { ExplorerLeaf } from './@types/obsidian';
+import type { ExplorerView } from './@types/obsidian';
 import { IconFolderSettings } from './settings';
 
 /**
@@ -152,16 +152,16 @@ export const customizeIconStyle = (plugin: IconFolderPlugin, icon: string, el: H
 export const addIconsToDOM = (
   plugin: IconFolderPlugin,
   data: [string, string | FolderIconObject][],
-  registeredFileExplorers: WeakMap<ExplorerLeaf, boolean>,
+  registeredFileExplorers: WeakSet<ExplorerView>,
   callback?: () => void,
 ): void => {
   const fileExplorers = plugin.app.workspace.getLeavesOfType('file-explorer');
   fileExplorers.forEach((fileExplorer) => {
-    if (registeredFileExplorers.has(fileExplorer)) {
+    if (registeredFileExplorers.has(fileExplorer.view)) {
       return;
     }
 
-    registeredFileExplorers.set(fileExplorer, true);
+    registeredFileExplorers.add(fileExplorer.view);
 
     // create a map with registered file paths to have constant look up time
     const registeredFilePaths: Record<string, boolean> = {};
@@ -219,13 +219,13 @@ export const addIconsToDOM = (
 
 export const addInheritanceIconToFile = (
   plugin: IconFolderPlugin,
-  registeredFileExplorers: WeakMap<ExplorerLeaf, boolean>,
+  registeredFileExplorers: WeakSet<ExplorerView>,
   filePath: string,
   iconName: string,
 ): void => {
   const fileExplorers = plugin.app.workspace.getLeavesOfType('file-explorer');
   fileExplorers.forEach((fileExplorer) => {
-    if (registeredFileExplorers.has(fileExplorer)) {
+    if (registeredFileExplorers.has(fileExplorer.view)) {
       const fileItem = fileExplorer.view.fileItems[filePath];
       if (fileItem) {
         const iconNode = fileItem.titleEl.createDiv();


### PR DESCRIPTION
`registeredFileExplorers` now use WeakSet instead of WeakMap;
track ExplorerView in `registeredFileExplorers` instead of ExplorerLeaf, as leaf may contain different view

this PR should fix compatibility issue with alx-folder-note v0.15.0+ caused by [view refresh after monkey-patches on ExplorerView's prototype](https://github.com/aidenlx/alx-folder-note/blob/81f125f7d455c7290c312050ce84b2d58739425b/src/fe-patch.ts#L136-L141). 