### PR TITLE
fix: add plugin name to Notice regarding bad path

### DIFF
--- a/src/MetaData.ts
+++ b/src/MetaData.ts
@@ -1,0 +1,4 @@
+
+export default class MetaData {
+  public static pluginName: string;
+}

--- a/src/iconPackManager.ts
+++ b/src/iconPackManager.ts
@@ -1,4 +1,5 @@
 import { Notice, Plugin } from 'obsidian';
+import MetaData from './MetaData';
 
 export interface Icon {
   name: string;
@@ -19,7 +20,7 @@ export const setPath = (newPath: string): void => {
   if (newPath === 'plugins/obsidian-icon-folder/icons') {
     newPath = '.obsidian/plugins/obsidian-icon-folder/icons';
     new Notice(
-      'Due to a change in version v1.2.2, the obsidian folder changed. Please change it to not be directly in /plugins.',
+      `[${MetaData.pluginName}] Due to a change in version v1.2.2, the obsidian folder changed. Please change it to not be directly in /plugins.`, 8000
     );
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import {
 } from './util';
 import { migrateIcons } from './migration';
 import IconFolderSettingsTab from './settingsTab';
+import MetaData from './MetaData';
 
 export interface FolderIconObject {
   iconName: string | null;
@@ -27,7 +28,8 @@ export default class IconFolderPlugin extends Plugin {
   private registeredFileExplorers = new WeakSet<ExplorerView>();
 
   async onload() {
-    console.log('loading obsidian-icon-folder');
+    MetaData.pluginName = this.manifest.id;
+    console.log(`loading ${MetaData.pluginName}`);
 
     await this.loadIconFolderData();
     setPath(this.getSettings().iconPacksPath);


### PR DESCRIPTION
Addresses #82

- Added `MetaData` class that has a single static property, `pluginName` that is set `onload`
  - uses `this.manifest.id` to get the plugin name from the obsidian plugin manifest
- Prepends the `MetaData.pluginName` to the Notice
- Sets the Notice timeout to 8000ms (8 seconds) to give users more time to read it

![CleanShot 2022-06-18 at 10 05 36](https://user-images.githubusercontent.com/149965/174442145-2c21b185-5405-4f3e-9d83-62e3a5e85b72.png)

