### PR TITLE
fix: rules icons doesn't apply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ devicon
 # obsidian
 data.json
 env.js
+*icons*

--- a/src/util.ts
+++ b/src/util.ts
@@ -203,7 +203,13 @@ export const addIconsToDOM = (
         plugin.app.vault.getAllLoadedFiles().forEach(async (file) => {
           const fileType = (await plugin.app.vault.adapter.stat(file.path)).type;
           const settingsFolder = checkIfFolderHasIconsSettings(plugin, file.path);
-          if (file.name.match(regex) && isToRuleApplicable(rule, fileType) && !settingsFolder) {
+          let checkingFolder = false; //can be changed by rule
+          // if setting folder is true => DON'T ADD ICON.
+          // if setting folder is false => ADD ICON.
+          if (settingsFolder == false) {
+            checkingFolder = true;
+          }
+          if (file.name.match(regex) && isToRuleApplicable(rule, fileType) && checkingFolder) {
             addCustomRuleIcon(rule, file.path);
           }
         });
@@ -211,8 +217,14 @@ export const addIconsToDOM = (
         // Rule is not applicable to a regex format.
         plugin.app.vault.getAllLoadedFiles().forEach(async (file) => {
           const settingsFolder = checkIfFolderHasIconsSettings(plugin, file.path);
+          let checkingFolder = false; //can be changed by rule
+          // if setting folder is true => DON'T ADD ICON.
+          // if setting folder is false => ADD ICON.
+          if (settingsFolder == false) {
+            checkingFolder = true;
+          }
           const fileType = (await plugin.app.vault.adapter.stat(file.path)).type;
-          if (file.name.includes(rule.rule) && isToRuleApplicable(rule, fileType) && !settingsFolder) {
+          if (file.name.includes(rule.rule) && isToRuleApplicable(rule, fileType) && checkingFolder) {
             addCustomRuleIcon(rule, file.path);
           }
         });
@@ -571,9 +583,18 @@ export const checkIfFolderHasIconsSettings = (plugin: IconFolderPlugin, folderPa
   allIcons.forEach((icon) => {
     folder.push(icon.key);
   });
+  const iconFolder = plugin.getData();
+  const inheritanceFolder = []
+  for (const i in iconFolder) {
+    if (typeof iconFolder[i] == 'object') {
+      if (iconFolder[i].hasOwnProperty('inheritanceIcon')) {
+        inheritanceFolder.push(i);
+      }
+    }
+  }
+  const inheritanceChecker = inheritanceFolder.filter(f => (folderPath.includes(f))).length>0
   // inheritance folder
-  const inheritanceChecker = folder.filter((f) => folderPath.includes(f)).length > 0;
-  return !!folder.includes(folderPath) || inheritanceChecker;
+  return folder.includes(folderPath) || inheritanceChecker ; //return true if the folder has icons
 };
 
 export const getIconsWithPathInData = (plugin: IconFolderPlugin) => {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,76 @@
+.obsidian-icon-folder-icon {
+  border: 1px solid transparent;
+  padding: 2px 2px 2px 2px;
+  display: flex;
+  margin: auto 0;
+}
+
+.obsidian-icon-folder-setting .setting-item-control .dropdown {
+  margin-right: 12px;
+}
+
+.obsidian-icon-folder-setting input[type='color'] {
+  margin: 0 6px;
+}
+
+.obsidian-icon-folder-modal.prompt-results {
+  margin: 0;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.prompt .obsidian-icon-folder-subheadline {
+  margin-top: 12px;
+  font-size: 12px;
+  color: gray;
+  grid-column-start: 1;
+  grid-column-end: 6;
+}
+
+.obsidian-icon-folder-modal.prompt-results .suggestion-item {
+  cursor: pointer;
+  white-space: pre-wrap;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-direction: column-reverse;
+  text-align: center;
+  font-size: 13px;
+  color: gray;
+  padding: 16px 8px;
+  line-break: auto;
+  word-break: break-word;
+  line-height: 1.3;
+}
+
+.obsidian-icon-folder-modal.prompt-results .suggestion-item.suggestion-item__center {
+  justify-content: center;
+}
+
+.obsidian-icon-folder-icon-preview img {
+  width: 16px;
+  height: 16px;
+}
+
+.obsidian-icon-folder-icon-preview svg {
+  width: 24px;
+  height: 24px;
+  color: currentColor;
+  margin-bottom: 4px;
+}
+
+.obsidian-icon-folder-dragover {
+  position: relative;
+}
+
+.obsidian-icon-folder-dragover-el {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  color: var(--text-normal);
+  background-color: var(--background-secondary-alt);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
see #68
I rebase the entire tree, I had a lot of problem.... So the file edited is in src/utils.css. I also edited the gitignore during the process, to add `icons` folder. Finally, I had also problem with style.css so I updated these manually.

Normally, fix #68. At last, I don't have any error on my side.

Note that this fix work as well for #86 

Note : I based this update on the 1.2.5 push, as the last commit broke the plugin in some way (Obsidian doesn't detect it either?)