### PR TITLE
fix: errors with drag to rearrage, including #115

### DIFF
--- a/src/@types/obsidian.d.ts
+++ b/src/@types/obsidian.d.ts
@@ -1,4 +1,4 @@
-import { TFile, View, WorkspaceLeaf } from 'obsidian';
+import { MarkdownView, TFile, View, WorkspaceLeaf } from 'obsidian';
 import IconFolderPlugin from '../main';
 
 interface InternalPlugin {
@@ -61,4 +61,9 @@ interface ExplorerView extends View {
 interface FileItem {
   titleEl: HTMLDivElement;
   titleInnerEl: HTMLDivElement;
+}
+
+interface MarkdownLeaf extends WorkspaceLeaf {
+  view: MarkdownView;
+  containerEl: HTMLElement;
 }

--- a/src/iconsPickerModal.ts
+++ b/src/iconsPickerModal.ts
@@ -1,7 +1,7 @@
 import twemoji from 'twemoji';
 import { App, FuzzyMatch, FuzzySuggestModal } from 'obsidian';
 import IconFolderPlugin from './main';
-import { addToDOM, getEnabledIcons, isEmoji } from './util';
+import { addIconsToDragToRearrange, addToDOM, getEnabledIcons, isEmoji } from './util';
 import { doesIconExists, getAllIconPacks, getSvgFromLoadedIcon, nextIdentifier } from './iconPackManager';
 
 type EnterScope = (() => void) | ((e: KeyboardEvent) => void);
@@ -112,6 +112,7 @@ export default class IconsPickerModal extends FuzzySuggestModal<any> {
       addToDOM(this.plugin, this.path, item);
     }
     this.plugin.addFolderIcon(this.path, item);
+    addIconsToDragToRearrange(this.plugin);
   }
 
   renderSuggestion(item: FuzzyMatch<Icon>, el: HTMLElement): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import {
   addCustomRuleIconsToDOM,
   doesCustomRuleIconExists,
   updateIcon,
-  addIconToDragToRearrange,
+  addIconsToDragToRearrange,
 } from './util';
 import { migrateIcons } from './migration';
 import IconFolderSettingsTab from './settingsTab';
@@ -91,6 +91,7 @@ export default class IconFolderPlugin extends Plugin {
             this.removeFolderIcon(file.path);
             removeFromDOM(file.path);
             updateIcon(this, file);
+            addIconsToDragToRearrange(this);
           });
         };
 
@@ -186,19 +187,12 @@ export default class IconFolderPlugin extends Plugin {
       }
     });
 
+    // Add icon to active file every layout change, so also works when splitting the workspace
+    addIconsToDragToRearrange(this);
+
     addIconsToDOM(this, data, this.registeredFileExplorers, () => {
       //const searchLeaveDom = this.getSearchLeave().dom;
       //searchLeaveDom.changed = () => this.addIconsToSearch();
-
-      // Add icon to active file
-      addIconToDragToRearrange(this, this.app.workspace.getActiveFile());
-
-      // Register event for manipulating view-header of drag to rearange icon.
-      this.registerEvent(
-        this.app.workspace.on('file-open', (file) => {
-          addIconToDragToRearrange(this, file);
-        }),
-      );
 
       // Register rename event for adding icons with custom rules to the DOM.
       this.registerEvent(


### PR DESCRIPTION
This pull request fixes issue #115 and improves the behaviour of drag to rearrange icons.

The drag to rearrange icons now:
- work fine when multiple panes are open with the same or different files. In the current version, when more than 1 file was open in a split view, the drag icons were not set correctly.
- update when the user changes the icon.
- update when the user removes the icon.
- show twemoji (#115)

I will explain the changes I made per file:
- `util.ts`: Changed the function `addIconToDragToRearrange` to `addIconsToDragToRearrange`.
  This function now sets all the icons for all the open markdown file views.
- `@types/obsidian.d.ts`: Type definitions for the `MarkdownLeaf`.
- `iconPickerModal.ts`: Now calls `addIconsToDragToRearrange` when an icon is selected to update the drag icons.
- `main.ts`:
  - Call `addIconsToDragToRearrange` when an icon is removed.
  - Call `addIconsToDragToRearrange` in every layout change.
  - Remove the call to `addIconToDragToRearrange` for the active file and on file open.