### PR TITLE
Change Twemoji CDN base in `parse` calls.

### DIFF
--- a/src/iconsPickerModal.ts
+++ b/src/iconsPickerModal.ts
@@ -134,7 +134,7 @@ export default class IconsPickerModal extends FuzzySuggestModal<any> {
         let displayName = '';
         switch (this.plugin.getSettings().emojiStyle) {
           case 'twemoji':
-            displayName = twemoji.parse(item.item.displayName);
+            displayName = twemoji.parse(item.item.displayName, {base: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/"});
             break;
           case 'native':
             displayName = item.item.displayName;

--- a/src/util.ts
+++ b/src/util.ts
@@ -530,6 +530,7 @@ export const insertIconToNode = (plugin: IconFolderPlugin, icon: string, node: H
     switch (plugin.getSettings().emojiStyle) {
       case 'twemoji':
         emoji = twemoji.parse(icon, {
+          base: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/',
           folder: 'svg',
           ext: '.svg',
           attributes: () => ({


### PR DESCRIPTION
Twemoji's canonical CDN has shut down: https://github.com/twitter/twemoji/issues/580

`cdnjs`, `jsdelivr`, and `unpkg` all have Twemoji CDN alternatives. And lucky for us, the `parse` call in to Twemoji can take a `base` parameter for the CDN URL.

This PR switches the base to the `cdnjs` version of Twemoji but that doesn't have to be the production solution. It could maybe even be a config option, idk. But this at least gets the plugin working again.