### PR TITLE
feat: add support for file-path in rules

### DIFF
--- a/src/lib/customRule.ts
+++ b/src/lib/customRule.ts
@@ -126,7 +126,7 @@ const add = async (
   if (!doesMatchFileType(rule, fileType) || hasIcon) {
     return;
   }
-  const toMatch = rule.filepath ? file.path : file.name;
+  const toMatch = rule.useFilePath ? file.path : file.name;
   try {
     // Rule is in some sort of regex.
     const regex = new RegExp(rule.rule);

--- a/src/lib/customRule.ts
+++ b/src/lib/customRule.ts
@@ -22,27 +22,6 @@ const doesMatchFileType = (rule: CustomRule, fileType: CustomRuleFileType): bool
 };
 
 /**
- * Determines whether a given filepath matches a specified custom rule.
- * @param rule Custom rule to check against the file.
- * @param path File path to check against the custom rule.
- * @returns True if the file matches the rule, false otherwise.
- */
-
-const doestMatchPath = (rule: CustomRule, path: string, fileType: CustomRuleFileType): boolean => {
-  // Gets the file type based on the specified file path.
-  if (!rule.filepath)
-    return doesMatchFileType(rule, fileType);
-  try {
-    // Rule is in some sort of regex.
-    const regex = new RegExp(rule.rule);
-    return path.match(regex) ? true : doesMatchFileType(rule, fileType);
-  } catch {
-    // Rule is not in some sort of regex, check for basic string match.
-    return path.includes(rule.rule) ? true : doesMatchFileType(rule, fileType);
-  }
-};
-
-/**
  * Determines whether a given file matches a specified custom rule.
  * @param plugin Plugin object containing the app and other plugin data.
  * @param rule Custom rule to check against the file.
@@ -144,10 +123,10 @@ const add = async (
   const fileType = (await plugin.app.vault.adapter.stat(file.path)).type;
 
   const hasIcon = plugin.getData()[file.path];
-  if (!doestMatchPath(rule, file.path, fileType) || hasIcon) {
+  if (!doesMatchFileType(rule, fileType) || hasIcon) {
     return;
   }
-  const toMatch = rule.filepath ? file.path : file.name;  
+  const toMatch = rule.filepath ? file.path : file.name;
   try {
     // Rule is in some sort of regex.
     const regex = new RegExp(rule.rule);

--- a/src/settings/data.ts
+++ b/src/settings/data.ts
@@ -9,6 +9,7 @@ export interface CustomRule {
   rule: string;
   icon: string;
   color?: string;
+  filepath?:boolean;
   for?: 'everything' | 'files' | 'folders';
 }
 

--- a/src/settings/data.ts
+++ b/src/settings/data.ts
@@ -9,7 +9,7 @@ export interface CustomRule {
   rule: string;
   icon: string;
   color?: string;
-  filepath?:boolean;
+  useFilePath?:boolean;
   for?: 'everything' | 'files' | 'folders';
 }
 

--- a/src/settings/ui/customIconRule.ts
+++ b/src/settings/ui/customIconRule.ts
@@ -204,12 +204,12 @@ export default class CustomIconRuleSetting extends IconFolderSetting {
           });
 
           new Setting(modal.contentEl)
-            .setName('File path')
-            .setDesc('Whether to apply the icon to all file/folder that match the filepath.')
+            .setName('Use file path')
+            .setDesc('Whether to apply the icon to all files/folders that match the file path.')
             .addToggle((toggle) => {
-              toggle.setValue(rule.filepath !== undefined);
+              toggle.setValue(rule.useFilePath !== undefined);
               toggle.onChange(async (value) => {
-                rule.filepath = value ? true : undefined;
+                rule.useFilePath = value;
               });
             });
 
@@ -229,7 +229,6 @@ export default class CustomIconRuleSetting extends IconFolderSetting {
             colorPicker.setValue('#000000');
             rule.color = undefined;
           });
-
 
           // Create the save button.
           const button = new ButtonComponent(modal.contentEl);

--- a/src/settings/ui/customIconRule.ts
+++ b/src/settings/ui/customIconRule.ts
@@ -203,6 +203,16 @@ export default class CustomIconRuleSetting extends IconFolderSetting {
             modal.open();
           });
 
+          new Setting(modal.contentEl)
+            .setName('File path')
+            .setDesc('Whether to apply the icon to all file/folder that match the filepath.')
+            .addToggle((toggle) => {
+              toggle.setValue(rule.filepath !== undefined);
+              toggle.onChange(async (value) => {
+                rule.filepath = value ? true : undefined;
+              });
+            });
+
           // Create the color picker for the rule.
           this.createDescriptionEl(modal.contentEl, 'Color of the icon');
           const colorContainer = modal.contentEl.createDiv();
@@ -219,6 +229,7 @@ export default class CustomIconRuleSetting extends IconFolderSetting {
             colorPicker.setValue('#000000');
             rule.color = undefined;
           });
+
 
           // Create the save button.
           const button = new ButtonComponent(modal.contentEl);


### PR DESCRIPTION
What I do:
- Added a new optional item for custom rules: `filepath` (boolean)
- Added a toggle for file-path application in the custom rules UI editor
- In the application of rules, check if the `rule.filepath` exists/is true. If yes, use the `file.path`, use the `file.name` otherwise.

This option support the file-type, so you can apply a rules on all folder with a specific filepath, or file with a specific filepath;

Fix #220 