### PR TITLE
fix(fix-mobile-icon): on mobile, custom rules doesn't load at startup

### DIFF
--- a/src/lib/custom-rule.ts
+++ b/src/lib/custom-rule.ts
@@ -190,7 +190,7 @@ const getFileItems = async (
 ): Promise<FileItem[]> => {
   const result: FileItem[] = [];
   for (const fileExplorer of plugin.getRegisteredFileExplorers()) {
-    const files = Object.values(fileExplorer.fileItems);
+    const files = Object.values(fileExplorer.fileItems || {});
     for (const fileItem of files) {
       if (await isApplicable(plugin, rule, fileItem.file.path)) {
         result.push(fileItem);

--- a/src/settings/ui/customIconRule.ts
+++ b/src/settings/ui/customIconRule.ts
@@ -180,7 +180,7 @@ export default class CustomIconRuleSetting extends IconFolderSetting {
 
         const addedPaths: string[] = [];
         for (const fileExplorer of this.plugin.getRegisteredFileExplorers()) {
-          const files = Object.values(fileExplorer.fileItems);
+          const files = Object.values(fileExplorer.fileItems || {});
           for (const rule of customRule.getSortedRules(this.plugin)) {
             // Removes the icon tabs from all opened files.
             this.updateIconTabs(rule, true, addedPaths);

--- a/src/settings/ui/emojiStyle.ts
+++ b/src/settings/ui/emojiStyle.ts
@@ -29,7 +29,7 @@ export default class EmojiStyleSetting extends IconFolderSetting {
 
   private updateDOM(): void {
     for (const fileExplorer of this.plugin.getRegisteredFileExplorers()) {
-      const fileItems = Object.entries(fileExplorer.fileItems);
+      const fileItems = Object.entries(fileExplorer.fileItems || {});
       for (const [path, _] of fileItems) {
         let iconName = this.plugin.getData()[path] as string | undefined | null;
         if (!iconName) {


### PR DESCRIPTION
See #617 
It fixes the error at startup when loading the rules on mobile.

Probably a not good fix, but it works, at last. 

Close #617

> [!NOTE]
> I needed to change the package json because pnpm run lint throw an error:
> ```
> Oops! Something went wrong! :(
>
> ESLint: 8.57.1
>
> No files matching the pattern "'*/**/*.{js,ts,tsx}'" were found.
> Please check for typing mistakes in the pattern.
> ```
> Removing the `'` around the pattern fix the things.
> Maybe switching to [@biomejs](https://biomejs.dev/) will be a good thing to remove dep?
