### PR TITLE
Add ability to Disable emoji suggestions in menu

### DIFF
--- a/src/editor/icons-suggestion.ts
+++ b/src/editor/icons-suggestion.ts
@@ -77,6 +77,9 @@ export default class SuggestionIcon extends EditorSuggest<string> {
       })
       .map((iconObject) => iconObject.prefix + iconObject.name);
 
+    if (this.plugin.getSettings().emojiStyle === 'disabled') {
+        return [...iconsNameArray]
+    }
     // Store all emojis correspoding to the current query - parsing whitespaces and
     // colons for shortcodes compatibility.
     const emojisNameArray = Object.keys(emoji.shortNames).filter((e) =>

--- a/src/settings/data.ts
+++ b/src/settings/data.ts
@@ -1,4 +1,4 @@
-export type EmojiStyle = 'native' | 'twemoji';
+export type EmojiStyle = 'native' | 'twemoji' | 'disabled';
 
 export enum IconInTitlePosition {
   Above = 'above',

--- a/src/settings/ui/emojiStyle.ts
+++ b/src/settings/ui/emojiStyle.ts
@@ -18,6 +18,7 @@ export default class EmojiStyleSetting extends IconFolderSetting {
     emojiStyle.addDropdown((dropdown) => {
       dropdown.addOption('native', 'Native');
       dropdown.addOption('twemoji', 'Twemoji');
+      dropdown.addOption('disabled', 'Disabled');
       dropdown.setValue(this.plugin.getSettings().emojiStyle);
       dropdown.onChange(async (value: 'native' | 'twemoji') => {
         this.plugin.getSettings().emojiStyle = value;

--- a/src/ui/icons-picker-modal.ts
+++ b/src/ui/icons-picker-modal.ts
@@ -24,6 +24,7 @@ export default class IconsPickerModal extends FuzzySuggestModal<any> {
     this.plugin = plugin;
     this.path = path;
     this.limit = 150;
+    this.emojiStyle = plugin.getSettings().emojiStyle;
 
     const pluginRecentltyUsedItems = [
       ...plugin.getSettings().recentlyUsedIcons,
@@ -59,6 +60,9 @@ export default class IconsPickerModal extends FuzzySuggestModal<any> {
     if (this.inputEl.value.length === 0) {
       this.renderIndex = 0;
       this.recentlyUsedItems.forEach((iconName) => {
+        if (this.emojiStyle === 'disabled' && emoji.isEmoji(iconName)) {
+          return;
+        }
         if (emoji.isEmoji(iconName)) {
           iconKeys.push({
             name: emoji.shortNames[iconName],
@@ -95,30 +99,30 @@ export default class IconsPickerModal extends FuzzySuggestModal<any> {
     for (const icon of this.plugin.getIconPackManager().allLoadedIconNames) {
       iconKeys.push(icon);
     }
-
-    Object.entries(emoji.shortNames).forEach(([unicode, shortName]) => {
-      iconKeys.push({
-        name: shortName,
-        prefix: 'Emoji',
-        displayName: unicode,
-        iconPackName: null,
-        filename: '',
-        svgContent: '',
-        svgElement: '',
-        svgViewbox: '',
+    if (this.emojiStyle !== 'disabled') {
+      Object.entries(emoji.shortNames).forEach(([unicode, shortName]) => {
+        iconKeys.push({
+          name: shortName,
+          prefix: 'Emoji',
+          displayName: unicode,
+          iconPackName: null,
+          filename: '',
+          svgContent: '',
+          svgElement: '',
+          svgViewbox: '',
+        });
+        iconKeys.push({
+          name: unicode,
+          prefix: 'Emoji',
+          displayName: unicode,
+          iconPackName: null,
+          filename: '',
+          svgContent: '',
+          svgElement: '',
+          svgViewbox: '',
+        });
       });
-      iconKeys.push({
-        name: unicode,
-        prefix: 'Emoji',
-        displayName: unicode,
-        iconPackName: null,
-        filename: '',
-        svgContent: '',
-        svgElement: '',
-        svgViewbox: '',
-      });
-    });
-
+    }
     return iconKeys;
   }
 


### PR DESCRIPTION
Added a dropdown option in the Emoji rendering style called 'Disabled' that will disable emoji suggestions to remove clutter when searching for icons.
Removes suggestions but still allows 'native' style in rendering to prevent existing / already set emoji icons from breaking.