### PR TITLE
Update download links for icon packs

### DIFF
--- a/src/icon-packs.ts
+++ b/src/icon-packs.ts
@@ -11,28 +11,28 @@ const predefinedIconPacks = {
     displayName: 'FontAwesome Brands',
     path: 'fontawesome-free-6.5.1-web/svgs/brands/',
     downloadLink:
-      'https://github.com/FortAwesome/Font-Awesome/releases/download/6.5.1/fontawesome-free-6.5.1-web.zip',
+      'https://github.com/FortAwesome/Font-Awesome/releases/download/7.2.0/fontawesome-free-7.2.0-web.zip',
   },
   faRegular: {
     name: 'font-awesome-regular',
     displayName: 'FontAwesome Regular',
     path: 'fontawesome-free-6.5.1-web/svgs/regular/',
     downloadLink:
-      'https://github.com/FortAwesome/Font-Awesome/releases/download/6.5.1/fontawesome-free-6.5.1-web.zip',
+      'https://github.com/FortAwesome/Font-Awesome/releases/download/7.2.0/fontawesome-free-7.2.0-web.zip',
   },
   faSolid: {
     name: 'font-awesome-solid',
     displayName: 'FontAwesome Solid',
     path: 'fontawesome-free-6.5.1-web/svgs/solid/',
     downloadLink:
-      'https://github.com/FortAwesome/Font-Awesome/releases/download/6.5.1/fontawesome-free-6.5.1-web.zip',
+      'https://github.com/FortAwesome/Font-Awesome/releases/download/7.2.0/fontawesome-free-7.2.0-web.zip',
   },
   remixIcons: {
     name: 'remix-icons',
     displayName: 'Remix Icons',
     path: '',
     downloadLink:
-      'https://github.com/Remix-Design/RemixIcon/releases/download/v4.2.0/RemixIcon_Svg_v4.2.0.zip',
+      'https://github.com/Remix-Design/RemixIcon/releases/download/v4.9.1/RemixIcon_Svg_v4.9.1.zip',
   },
   iconBrew: {
     name: 'icon-brew',
@@ -47,14 +47,14 @@ const predefinedIconPacks = {
     displayName: 'Simple Icons',
     path: 'simple-icons-16.5.0/icons/',
     downloadLink:
-      'https://github.com/simple-icons/simple-icons/archive/refs/tags/16.5.0.zip',
+      'https://github.com/simple-icons/simple-icons/archive/refs/tags/16.15.0.zip',
   },
   lucide: {
     name: 'lucide-icons',
     displayName: 'Lucide',
     path: '',
     downloadLink:
-      'https://github.com/lucide-icons/lucide/releases/download/0.363.0/lucide-icons-0.363.0.zip',
+      'https://github.com/lucide-icons/lucide/releases/download/1.7.0/lucide-icons-1.7.0.zip',
   },
   tablerIcons: {
     name: 'tabler-icons',


### PR DESCRIPTION
Update FontAwesome, Remix Icons, Simple Icons and Lucide icons source URLs.